### PR TITLE
支持不同的认证网关 Support custom srun authentication portal via auth_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Usage: bitsrun status [OPTIONS]
   Check current network login status.
 
 Options:
-  --json / --no-json  Output in JSON format.
-  --help  Show this message and exit.
+  --json / --no-json   Output in JSON format.
+  -a, --auth_url TEXT  Authentication portal URL. (Optional)
+  --help               Show this message and exit.
 ```
 
 > **Note**: this is the output of `bitsrun status --help`.
@@ -69,6 +70,7 @@ Usage: bitsrun login/logout [OPTIONS]
 Options:
   -u, --username TEXT  Your username.
   -p, --password TEXT  Your password.
+  -a, --auth_url TEXT  Authentication portal URL. (Optional)
   -v, --verbose        Verbosely echo API response.
   --help               Show this message and exit.
 ```
@@ -112,6 +114,19 @@ To list all possible paths for your system (including those only for backward co
 bitsrun config-paths
 ```
 
+### Srun at other campuses
+
+This script also works for other campuses using srun authentication. If your campus uses a different authentication portal, just add the `"auth_url"` field to your `bit-user.json` config file:
+
+```json
+{
+    "username": "xxxx",
+    "password": "xxxx",
+    "auth_url": "http(s)://your-portal-address"
+}
+```
+
+Or use the `--auth_url` option in CLI commands. This makes bitsrun compatible with other schools or custom portals.
 ### Raycast script (macOS)
 
 ![raycast screenshot](https://user-images.githubusercontent.com/32114380/213919582-eff6d58f-1bd2-47b2-a5da-46dc6e2eaffa.png)

--- a/src/bitsrun/cli.py
+++ b/src/bitsrun/cli.py
@@ -15,6 +15,7 @@ from bitsrun.utils import print_status_table
 _options = [
     click.option('-u', '--username', help='Your username.', required=False),
     click.option('-p', '--password', help='Your password.', required=False),
+    click.option('-a', '--auth_url', default='http://10.0.0.55', help='Authentication portal URL. (Optional)'),
     click.option('-v', '--verbose', is_flag=True, help='Verbosely echo API response.'),
 ]
 
@@ -51,9 +52,10 @@ def config_paths():
 
 @cli.command()
 @click.option('--json/--no-json', default=False, help='Output in JSON format.')
-def status(json: bool):
+@click.option('-a', '--auth_url', default='http://10.0.0.55', help='Authentication portal URL. (Optional)')
+def status(json: bool, auth_url: str):
     """Check current network login status."""
-    login_status = get_login_status()
+    login_status = get_login_status(auth_url)
 
     # Output in JSON format if `--json` is passed, then exit
     if json:
@@ -76,19 +78,19 @@ def status(json: bool):
 
 @cli.command()
 @add_options(_options)
-def login(username, password, verbose):
+def login(username, password, auth_url, verbose):
     """Log into the BIT network."""
-    do_action('login', username, password, verbose)
+    do_action('login', username, password, auth_url, verbose)
 
 
 @cli.command()
 @add_options(_options)
-def logout(username, password, verbose):
+def logout(username, password, auth_url, verbose):
     """Log out of the BIT network."""
-    do_action('logout', username, password, verbose)
+    do_action('logout', username, password, auth_url, verbose)
 
 
-def do_action(action, username, password, verbose):
+def do_action(action, username, password, auth_url, verbose):
     # Support reading password from stdin when not passed via `--password`
     if username and not password:
         password = getpass(prompt='Please enter your password: ')
@@ -97,7 +99,7 @@ def do_action(action, username, password, verbose):
         # Try to read username and password from args provided. If none, look for config
         # files in possible paths. If none, fail and prompt user to provide one.
         if username and password:
-            user = User(username, password)
+            user = User(username, password, auth_url)
         elif conf := read_config():
             if verbose:
                 click.echo(


### PR DESCRIPTION
TLDR: 支持自定义 srun 认证 portal，兼容外校/不同认证地址。

修改内容：
1. 在 user.py 相关逻辑中增加了 auth_url 参数，所有认证相关请求均可自定义 portal 地址。
2. 对所有的CLI命令（如 login/logout/status）均支持 --auth_url 参数，用户可通过命令行指定认证 portal。
3. README 增加了“Srun at other campuses”部分，说明如何通过 auth_url 字段或 CLI 参数兼容其他学校或自定义 portal。

需要讨论+可能可以改进的地方：
1. 我在status和log{in/out}分别添加了auth_url的命令行参数，是否有更优雅的方法
2. 需要review是否影响了不添加auth_url时的代码表现